### PR TITLE
Allow updating comment instead of creating a new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,30 @@ jobs:
 
 ## Inputs
 
-| Name         | Required | Description                                                    | Default |
-| ------------ | -------- | -------------------------------------------------------------- | ------- |
-| `repo-token` | true     | The GITHUB_TOKEN, required to comment.                         |         |
-| `silent`     | false    | Optional flag that turns off the comment on the PR.            | `false` |
-| `tour-path`  | false    | Optional flag that specifies a custom `.tour` folder location. | `.tour` |
+| Name         | Required | Description                                                     | Default  |
+| ------------ | -------- | --------------------------------------------------------------- | -------- |
+| `repo-token` | true     | The GITHUB_TOKEN, required to comment.                          |          |
+| `silent`     | false    | Optional flag that turns off the comment on the PR.             | `false`  |
+| `tour-path`  | false    | Optional flag that specifies a custom `.tours` folder location. | `.tours` |
+| `comment-id` | false    | ID of the comment to update (instead of creating a new one)     | `''`     |
+
+### Updating the comment instead of creating a new one
+
+This action can be used together with [peter-evans/find-comment](https://github.com/peter-evans/find-comment) to update the comment instead of creating a new one:
+
+```yml
+- name: Find codetour-watch comment
+  uses: peter-evans/find-comment@v1
+  id: find_comment
+  with:
+      issue-number: ${{ github.event.pull_request.number }}
+      body-includes: 'CodeTour Watch'
+- name: 'Watch CodeTour changes'
+  uses: pozil/codetour-watch@v1.1.0
+  with:
+      repo-token: ${{ secrets.GITHUB_TOKEN }}
+      comment-id: ${{ steps.find_comment.outputs.comment-id }}
+```
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
         description: 'Optional flag that specifies a custom `.tour` folder location.'
         required: false
         default: '.tours/'
+    comment-id:
+        description: 'ID of the comment to update (instead of creating a new one)'
+        required: false
+        default: ''
 
 runs:
     using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -6,8 +6,12 @@ inputs:
         required: true
     silent:
         description: 'Optional flag that turns off the comment on the PR.'
+        required: false
+        default: 'false'
     tour-path:
         description: 'Optional flag that specifies a custom `.tour` folder location.'
+        required: false
+        default: '.tours/'
 
 runs:
     using: 'node12'


### PR DESCRIPTION
## What changes are included in this PR?

A new optional action input is added: `comment-id`. This input can be set to a comment ID that will be updated (using [this method](https://octokit.github.io/rest.js/v18#issues-update-comment)) in case there are any warnings (instead of creating a new one).

The comment ID can be found by using this action along with [peter-evans/find-comment](https://github.com/peter-evans/find-comment).

### Possible future improvements

Remove the comment if the warnings are fixed.

