### PR TITLE
Update report comment instead of creating new one each time

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,30 @@ jobs:
 
 ## Inputs
 
-| Name         | Required | Description                                                    | Default |
-| ------------ | -------- | -------------------------------------------------------------- | ------- |
-| `repo-token` | true     | The GITHUB_TOKEN, required to comment.                         |         |
-| `silent`     | false    | Optional flag that turns off the comment on the PR.            | `false` |
-| `tour-path`  | false    | Optional flag that specifies a custom `.tour` folder location. | `.tour` |
+| Name         | Required | Description                                                     | Default  |
+| ------------ | -------- | --------------------------------------------------------------- | -------- |
+| `repo-token` | true     | The GITHUB_TOKEN, required to comment.                          |          |
+| `silent`     | false    | Optional flag that turns off the comment on the PR.             | `false`  |
+| `tour-path`  | false    | Optional flag that specifies a custom `.tours` folder location. | `.tours` |
+| `comment-id` | false    | ID of the comment to update (instead of creating a new one)     | `''`     |
+
+### Updating the comment instead of creating a new one
+
+This action can be used together with [peter-evans/find-comment](https://github.com/peter-evans/find-comment) to update the comment instead of creating a new one:
+
+```yml
+- name: Find codetour-watch comment
+  uses: peter-evans/find-comment@v1
+  id: find_comment
+  with:
+      issue-number: ${{ github.event.pull_request.number }}
+      body-includes: 'CodeTour Watch'
+- name: 'Watch CodeTour changes'
+  uses: pozil/codetour-watch@v1.1.0
+  with:
+      repo-token: ${{ secrets.GITHUB_TOKEN }}
+      comment-id: ${{ steps.find_comment.outputs.comment-id }}
+```
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -38,24 +38,6 @@ jobs:
 | `tour-path`  | false    | Optional flag that specifies a custom `.tours` folder location. | `.tours` |
 | `comment-id` | false    | ID of the comment to update (instead of creating a new one)     | `''`     |
 
-### Updating the comment instead of creating a new one
-
-This action can be used together with [peter-evans/find-comment](https://github.com/peter-evans/find-comment) to update the comment instead of creating a new one:
-
-```yml
-- name: Find codetour-watch comment
-  uses: peter-evans/find-comment@v1
-  id: find_comment
-  with:
-      issue-number: ${{ github.event.pull_request.number }}
-      body-includes: 'CodeTour Watch'
-- name: 'Watch CodeTour changes'
-  uses: pozil/codetour-watch@v1.1.0
-  with:
-      repo-token: ${{ secrets.GITHUB_TOKEN }}
-      comment-id: ${{ steps.find_comment.outputs.comment-id }}
-```
-
 ## Outputs
 
 | Name                 | Description                                                                          |

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
         description: 'Optional flag that specifies a custom `.tour` folder location.'
         required: false
         default: '.tours/'
+    comment-id:
+        description: 'ID of the comment to update (instead of creating a new one)'
+        required: false
+        default: ''
 
 runs:
     using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -6,8 +6,12 @@ inputs:
         required: true
     silent:
         description: 'Optional flag that turns off the comment on the PR.'
+        required: false
+        default: 'false'
     tour-path:
         description: 'Optional flag that specifies a custom `.tour` folder location.'
+        required: false
+        default: '.tours/'
 
 runs:
     using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -12,10 +12,6 @@ inputs:
         description: 'Optional flag that specifies a custom `.tour` folder location.'
         required: false
         default: '.tours/'
-    comment-id:
-        description: 'ID of the comment to update (instead of creating a new one)'
-        required: false
-        default: ''
 
 runs:
     using: 'node12'

--- a/src/index.js
+++ b/src/index.js
@@ -106,16 +106,20 @@ const run = async () => {
  * @returns {number} comment id or null if none found
  */
 const getCodeTourWatchComment = async (octokit, owner, repo, prNumber) => {
-    const comments = await octokit.paginate(octokit.issues.listComments, {
-        owner,
-        repo,
-        issue_number: prNumber
-    });
-    comments.reverse();
-    const comment = comments.find((comment) =>
-        COMMENT_PREFIX_REGEX.test(comment.body)
-    );
-    return comment ? comment.id : null;
+    try {
+        const comments = await octokit.paginate(octokit.issues.listComments, {
+            owner,
+            repo,
+            issue_number: prNumber
+        });
+        comments.reverse();
+        const comment = comments.find((comment) =>
+            COMMENT_PREFIX_REGEX.test(comment.body)
+        );
+        return comment ? comment.id : null;
+    } catch (error) {
+        throw new Error(`Failed to retrieved PR comments: ${error}`);
+    }  
 };
 
 /**
@@ -166,7 +170,7 @@ Changed files with possible CodeTour impact:\n\n`;
  */
 const getPrFiles = async (octokit, prInfo) => {
     try {
-        const prDetails = await octokit.paginate(octokit.pulls.listFiles, prInfo);
+        const prDetails = await octokit.pulls.listFiles(prInfo);
         return prDetails.data.map((file) => file.filename);
     } catch (error) {
         throw new Error(`Failed to retrieved PR files: ${error}`);


### PR DESCRIPTION
With this PR the action will automatically update the last report comment instead of creating a new comment each time.

Thanks to @alejandrohdezma for the contribution.