### PR TITLE
Don't fail if no code-tours are found and the `tour-path` input is the default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -204,7 +204,9 @@ const getCodetourFromFiles = (tourDefinitions, files) => {
  * @param {object[]} definitions
  */
 function loadToursFromDirectory(dirPath, definitions) {
-    if (!fs.existsSync(dirPath) && dirPath === DEFAULT_TOUR_PATH) return
+    if (!fs.existsSync(dirPath) && dirPath === DEFAULT_TOUR_PATH) {
+        return;
+    }
 
     // List files in folder
     let files;


### PR DESCRIPTION
This will help to share workflows that use this action across different repositories, where some of them might not have yet code tours.

Ensures that if the user passes a different `tour-path` folder, it should contain code-tours.