### PR TITLE
Use default GITHUB_TOKEN by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,8 @@ description: 'Flags file changes that may affect CodeTour content'
 inputs:
     repo-token:
         description: 'The GITHUB_TOKEN, needed to comment the PR.'
-        required: true
+        required: false
+        default: ${{ github.token }}
     silent:
         description: 'Optional flag that turns off the comment on the PR.'
         required: false


### PR DESCRIPTION
This makes the `github-token` input non-mandatory, for cases where the default `GITHUB_TOKEN` is used.